### PR TITLE
linuxdeployqt-3-x86_64.AppImage

### DIFF
--- a/MustBeUsedInMainJobFiles/Recipe.erb
+++ b/MustBeUsedInMainJobFiles/Recipe.erb
@@ -28,7 +28,7 @@ rm -f functions.sh
 mkdir /<%= name %>.AppDir/
 
 cd /
-wget https://github.com/probonopd/linuxdeployqt/releases/download/1/linuxdeployqt-1-x86_64.AppImage
+wget https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage
 chmod a+x linuxdeployqt-1-x86_64.AppImage
 
 cd /<%= name %>.AppDir


### PR DESCRIPTION
Fixes `--appimage-extract` and has beginning FHS-like mode support; no longer uses qt.conf. ATTENTION: Does not work with distro-provided Qt. Use Qt from beineri ppa instead.